### PR TITLE
Service status toggle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,20 +79,10 @@
       <version>4.0.1</version> <!-- Weld 5.1.0.Final is CDI 4.0 -->
     </dependency>
 
-    <!-- Weld (CDI Implementation) -->
-    <dependency>
-      <groupId>org.jboss.weld.servlet</groupId>
-      <artifactId>weld-servlet-core</artifactId>
-      <version>${weld.version}</version>
-    </dependency>
+
 
     <!-- PrimeFaces -->
-    <dependency>
-      <groupId>org.primefaces</groupId>
-      <artifactId>primefaces</artifactId>
-      <version>15.0.0</version>
-      <classifier>jakarta</classifier>
-    </dependency>
+
     <dependency>
       <groupId>org.primefaces.themes</groupId>
       <artifactId>all-themes</artifactId>
@@ -124,24 +114,8 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Jakarta EE Web APIs - Provided by Tomcat (Servlet, JSP, EL, etc.) -->
-    <dependency>
-      <groupId>jakarta.platform</groupId>
-      <artifactId>jakarta.jakartaee-web-api</artifactId>
-      <version>10.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- JSF Implementation (Mojarra) - Includes JSF API -->
-    <!-- Scope defaults to 'compile', which is what we want for bundling -->
 
 
-    <!-- CDI API - Must be bundled for Tomcat -->
-    <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <version>4.0.1</version>
-    </dependency>
 
     <!-- Weld (CDI Reference Implementation) - Must be bundled for Tomcat -->
     <!-- This will pull in weld-api and weld-spi transitively with matching versions -->
@@ -180,12 +154,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>3.4.0</version> <!-- Updated to latest -->
-
-
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -210,8 +178,6 @@
             <configuration>
 
               <outputDirectory>${basedir}/target/city_care_hms/resources
-
-              <outputDirectory>${basedir}/target/first_app/resources
 
               </outputDirectory>
               <resources>

--- a/src/main/java/backingbeans/admin/ServiceCatalogAdminBean.java
+++ b/src/main/java/backingbeans/admin/ServiceCatalogAdminBean.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.Min;
 import models.ServiceCatalogItem;
 import constants.ServiceCategory; // Your enum
 
+import models.Staff;
 import services.impl.ServiceCatalogServiceImpl;
 
 import java.io.Serializable;
@@ -105,6 +106,51 @@ public class ServiceCatalogAdminBean implements Serializable {
                     "Could not add service to catalog. It might already exist or an error occurred."));
         }
     }
+    public void deactivateService(ServiceCatalogItem serviceToDeactivate) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (serviceToDeactivate != null) {
+            System.out.println("Attempting to delete staff: " + serviceToDeactivate.getName());
+            boolean success = serviceCatalogService.deactivateService(serviceToDeactivate); // Assuming deleteStaff takes ID or object
+            if (success) {
+                context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, "Warning",
+                        "Service '" + serviceToDeactivate.getName() + "' has  been deactivated."));
+            }
+            loadCatalogItems(); // Refresh the list after deletion
+            // Add FacesMessage for success/failure
+        }
+    }
+
+    public void activateService(ServiceCatalogItem serviceToReactivate) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (serviceToReactivate != null) {
+            System.out.println("Attempting to delete staff: " + serviceToReactivate.getName());
+           boolean success =  serviceCatalogService.activateService(serviceToReactivate); // Assuming deleteStaff takes ID or object
+            if (success) {
+                context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, "Success",
+                        "Service '" + serviceToReactivate.getName() + "' has  been activated."));
+            }
+            loadCatalogItems(); // Refresh the list after deletion
+            // Add FacesMessage for success/failure
+        }
+    }
+
+    public void toggleServiceStatus(ServiceCatalogItem item) {
+        if (item == null) return;
+
+        if (item.isActive()) {
+            deactivateService(item);
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Service Deactivated",
+                            item.getName() + " has been deactivated."));
+        } else {
+            activateService(item);
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Service Activated",
+                            item.getName() + " has been activated."));
+        }
+    }
+
+
 
     // Getters and Setters
     public List<ServiceCatalogItem> getCatalogItems() { return catalogItems; }

--- a/src/main/java/dao/ServiceCatalogItemDao.java
+++ b/src/main/java/dao/ServiceCatalogItemDao.java
@@ -10,4 +10,6 @@ public interface ServiceCatalogItemDao extends Serializable {
     public Optional<ServiceCatalogItem> findByCode(String code);
     public Optional<ServiceCatalogItem> findByName(String name);
     public List<ServiceCatalogItem> findActiveItems();
+    public boolean deactivateItem(ServiceCatalogItem item);
+    public boolean activateItem(ServiceCatalogItem item);
 }

--- a/src/main/java/dao/impl/ServiceCatalogItemDaoImpl.java
+++ b/src/main/java/dao/impl/ServiceCatalogItemDaoImpl.java
@@ -45,4 +45,23 @@ public class ServiceCatalogItemDaoImpl extends AbstractDao<ServiceCatalogItem, L
             return query.getResultList();
         });
     }
+
+    @Override
+    public boolean deactivateItem(ServiceCatalogItem item) {
+        execute(session -> {
+            item.setActive(false);
+            session.merge(item);
+            return true;
+        });
+        return false;
+    }
+    @Override
+    public boolean activateItem(ServiceCatalogItem item) {
+        execute(session -> {
+            item.setActive(true);
+            session.merge(item);
+            return true;
+        });
+        return false;
+    }
 }

--- a/src/main/java/services/ServiceCatalogService.java
+++ b/src/main/java/services/ServiceCatalogService.java
@@ -13,4 +13,6 @@ public interface ServiceCatalogService {
     public boolean serviceNameExists(String serviceName);
     public List<ServiceCatalogItem> getActiveServiceCatalogItems();
     public Optional<ServiceCatalogItem> addServiceToCatalog(String serviceCode, String name, double cost, ServiceCategory category, String description);
+    public boolean deactivateService(ServiceCatalogItem serviceCatalogItem);
+    public boolean activateService(ServiceCatalogItem serviceCatalogItem);
 }

--- a/src/main/java/services/impl/ServiceCatalogServiceImpl.java
+++ b/src/main/java/services/impl/ServiceCatalogServiceImpl.java
@@ -129,4 +129,13 @@ public class ServiceCatalogServiceImpl implements ServiceCatalogService {
         serviceCatalogItemDao.save(newItem);
         return Optional.of(newItem);
     }
+    @Override
+    public boolean deactivateService(ServiceCatalogItem serviceCatalogItem){
+        return serviceCatalogItemDao.deactivateItem(serviceCatalogItem);
+    }
+
+    @Override
+    public boolean activateService(ServiceCatalogItem serviceCatalogItem){
+        return serviceCatalogItemDao.activateItem(serviceCatalogItem);
+    }
 }

--- a/src/main/webapp/WEB-INF/includes/admin/manage_service_catalog.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/manage_service_catalog.xhtml
@@ -22,7 +22,8 @@
 
     <p:panel header="Manage Service Catalog" styleClass="admin-form">
         <h:form id="serviceCatalogForm">
-            <p:messages id="catalogMessages" showDetail="true" closable="true" autoUpdate="true"/>
+            <p:messages id="catalogMessages" showDetail="true" closable="true" autoUpdate="true" />
+            <p:growl id="growl" showDetail="true" life="4000" />
 
             <p:fieldset legend="Add New Service Item" toggleable="true" collapsed="false">
                 <p:panelGrid columns="2" layout="grid" styleClass="ui-panelgrid-blank ui-fluid"
@@ -73,6 +74,7 @@
             </p:fieldset>
 
             <p:fieldset legend="Existing Service Items" toggleable="true" collapsed="true" style="margin-top:20px;">
+
                 <p:dataTable id="catalogTable" var="item" value="#{serviceCatalogAdminBean.catalogItems}"
                              paginator="true" rows="10" emptyMessage="No services found in catalog." reflow="true">
                     <p:column headerText="Code" sortBy="#{item.serviceCode}" filterBy="#{item.serviceCode}" filterMatchMode="contains">
@@ -95,15 +97,16 @@
                             <f:convertNumber type="currency" currencySymbol="UGX "/>
                         </h:outputText>
                     </p:column>
-                    <p:column headerText="Active" sortBy="#{item.active}" style="text-align:center; width:80px;">
-                        <p:selectBooleanCheckbox value="#{item.active}" disabled="true"/> <!-- Display only -->
-                    </p:column>
                     <p:column headerText="Actions" style="width:100px;text-align:center;">
                         <p:commandButton icon="pi pi-pencil" title="Edit" styleClass="rounded-button ui-button-info"
                                          disabled="true"/> <!-- Placeholder for edit functionality -->
-                        <p:commandButton icon="pi pi-power-off" title="#{item.active ? 'Deactivate' : 'Activate'}"
-                                         styleClass="rounded-button #{item.active ? 'ui-button-danger' : 'ui-button-success'}"
-                                         disabled="true" style="margin-left:5px;"/> <!-- Placeholder -->
+                        <p:commandButton value="#{item.active ? 'Deactivate' : 'Activate'}"
+                                         action="#{serviceCatalogAdminBean.toggleServiceStatus(item)}"
+                                         update="@form :growl"
+                                         process="@this"
+                                         icon="#{item.active ? 'pi pi-times' : 'pi pi-check'}"/>
+
+                        <!-- Placeholder -->
                     </p:column>
                 </p:dataTable>
             </p:fieldset>


### PR DESCRIPTION
This pull request introduces the status toggle feature.

This allows the admin to toggle the status of a given service by toggling it to active or inactive.This was made possible by adding  methods in the ServiceCatalogItemDao and implement it in ServiceCatalogItemDaoImpl  (activate and deactivate) and these methods were called into the ServiceCatalogServiceImpl via a method which is then called by a method in ServiceCatalogAdminBean and that method is use in manage_service_catalog.xhtml in order to achieve the desired goal.

In order to test this feature, You first need to login as an admin, navigate to Service Catalog, under Existing service item and click the Deactivate or Activate button of a given Item to toggle it's status.
