### PR TITLE
Fix time slot not showing

### DIFF
--- a/src/main/webapp/WEB-INF/includes/doctor/manage_schedule.xhtml
+++ b/src/main/webapp/WEB-INF/includes/doctor/manage_schedule.xhtml
@@ -21,13 +21,13 @@
                                 mindate="#{cc.attrs.today}">
                      <p:ajax event="dateSelect"
                              listener="#{doctorScheduleBean.loadExistingSlotsForDate}"
-                             update="existingSlotsPanel newSlotsPanel scheduleMessages" />
+                             update="@form" />
                   </p:datePicker>
                </div>
                <div class="col-12 md:col-6 lg:col-2 align-self-end">
                   <p:commandButton value="View Date"
                                    action="#{doctorScheduleBean.loadExistingSlotsForDate}"
-                                   update="existingSlotsPanel newSlotsPanel scheduleMessages"
+                                   update="@form"
                                    icon="pi pi-search"
                                    styleClass="mt-3" />
                </div>
@@ -77,7 +77,7 @@
                   <p:column headerText="Actions" style="width: 100px; text-align: center;">
                      <p:commandButton icon="pi pi-trash" title="Remove Slot"
                                       action="#{doctorScheduleBean.removeSlot(slot)}"
-                                      update="existingSlotsPanel scheduleMessages"
+                                      update="@form:existingSlotsPanel scheduleMessages"
                                       process="@this"
                                       styleClass="ui-button-danger">
                         <p:confirm header="Confirmation"


### PR DESCRIPTION
This pull request fixed a bug on the doctor schedule user interface causing the time slots to not show
Its was the update tag on the commandButoon component causing it to crush while loading the time slots.
I fixed it by changing the update="scheduledAppointmentsPanel completedAppointmentsPanel " to update=" @form" .
In order to check the fix, you need to login as a doctor and navigate to My schedule page and select a date and the time slots for that date will show if they exist.