### PR TITLE
Receptionist manages all appointments

### DIFF
--- a/src/main/java/org/pahappa/systems/hms/dao/impl/AppointmentDaoImpl.java
+++ b/src/main/java/org/pahappa/systems/hms/dao/impl/AppointmentDaoImpl.java
@@ -74,6 +74,23 @@ public class AppointmentDaoImpl extends AbstractDao<Appointment, Long> implement
     }
 
     @Override
+    public List<Appointment> findAll() {
+        return execute(session -> {
+            Query<Appointment> query = session.createQuery(
+                    "FROM Appointment a ", Appointment.class);
+            List<Appointment> result =  query.getResultList();
+            if (!result.isEmpty()){
+                for(Appointment appointment : result){
+                    Hibernate.initialize(appointment.getPatient());
+                    Hibernate.initialize(appointment.getDoctor());
+                    Hibernate.initialize(appointment.getBill());
+                }
+            }
+            return result;
+        });
+    }
+
+    @Override
     public List<Appointment> findByStatus( AppointmentStatus status) {
         return execute(session -> {
             Query<Appointment> query = session.createQuery(

--- a/src/main/java/org/pahappa/systems/hms/services/impl/AppointmentServiceImpl.java
+++ b/src/main/java/org/pahappa/systems/hms/services/impl/AppointmentServiceImpl.java
@@ -295,11 +295,11 @@ public class AppointmentServiceImpl {
     }
 
 
-    public List<Appointment> findCompletedAppointments() {
+    public List<Appointment> findAllAppointments() {
 
         try {
             System.err.println("Fetching completed appointments.");
-            return appointmentDao.findByStatus(AppointmentStatus.COMPLETED);
+            return appointmentDao.findAll();
         } catch (Exception e) {
 
             e.printStackTrace(); // Log error

--- a/src/main/java/views/staff/AppointmentsListBean.java
+++ b/src/main/java/views/staff/AppointmentsListBean.java
@@ -14,13 +14,13 @@ import java.util.List;
 
 @Named
 @ViewScoped
-public class CompletedAppointmentListBean implements Serializable {
+public class AppointmentsListBean implements Serializable {
 
     private final AppointmentServiceImpl appointmentService;
 
     private List<Appointment> appointmentList;
 
-    public CompletedAppointmentListBean() {
+    public AppointmentsListBean() {
         this.appointmentService = new  AppointmentServiceImpl();
     }
 
@@ -30,7 +30,7 @@ public class CompletedAppointmentListBean implements Serializable {
     }
 
     private void loadAppointments() {
-        appointmentList = appointmentService.findCompletedAppointments();
+        appointmentList = appointmentService.findAllAppointments();
         if (appointmentList == null) {
             appointmentList = new ArrayList<>(); // Avoid NullPointerException in DataTable
             System.err.println("AppointmentListBean: hospitalService.getAllStaffs() returned null.");

--- a/src/main/webapp/WEB-INF/includes/admin/patient_list.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/patient_list.xhtml
@@ -15,6 +15,7 @@
                 <p:toolbarGroup>
                     <p:commandButton value="Register Patient" icon="pi pi-plus" styleClass="ui-button-success"
                                      action="#{pageNavigationBean.navigateAddNewPatient}"
+                                     update=":pageContentForm:mainContentPanel"
                                     process="@this"
                     />
                 </p:toolbarGroup>

--- a/src/main/webapp/WEB-INF/includes/admin/staff_list.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/staff_list.xhtml
@@ -14,6 +14,7 @@
                 <p:toolbarGroup>
                     <p:commandButton value="Add New Staff" icon="pi pi-plus" styleClass="ui-button-success"
                                      action="#{pageNavigationBean.navigateAddNewStaff}"
+                                     update=":pageContentForm:mainContentPanel"
                                     process="@this"
                     />
                 </p:toolbarGroup>

--- a/src/main/webapp/WEB-INF/includes/receptionist/completed_appointment_list.xhtml
+++ b/src/main/webapp/WEB-INF/includes/receptionist/completed_appointment_list.xhtml
@@ -10,12 +10,12 @@
 
          <p:toolbar>
             <p:toolbarGroup>
-               <p:commandButton value="Refresh List" action="#{completedAppointmentListBean.refreshList}"
+               <p:commandButton value="Refresh List" action="#{appointmentsListBean.refreshList}"
                                 update="appointmentTable" icon="pi pi-refresh"/>
             </p:toolbarGroup>
          </p:toolbar>
 
-         <p:dataTable id="appointmentTable" var="aptmnt" value="#{completedAppointmentListBean.appointmentList}"
+         <p:dataTable id="appointmentTable" var="aptmnt" value="#{appointmentsListBean.appointmentList}"
                       emptyMessage="No Appointment members found."
                       style="margin-top:10px;"
                       reflow="true">
@@ -37,14 +37,29 @@
             </p:column>
 
             <p:column headerText="Actions" style="width:10%; text-align:center;">
-               <p:commandButton value="Generate Bill" title="Generate Bill"
-                                action="..."
-                                process="@this"
-                                update=":pageContentForm:mainContentPanel"
-                                styleClass="ui-button-warning" style="margin-right: .5em;">
-                  <p:confirm header="Confirmation" message="Are you sure you want to Reschedule ?" icon="pi pi-exclamation-triangle"/>
-                  <!-- This button will call prepareReschedule, then JSF will navigate (implicitly via pageNavigationBean if prepareReschedule sets it) -->
-               </p:commandButton>
+               <p:menuButton icon="pi pi-ellipsis-v" buttonStyleClass="rounded-button ui-button-flat">
+                  <p:menuitem value="Reschedule"
+                              icon="pi pi-calendar-plus"
+                              title="Reschedule Appointment"
+                              action="#{appointmentRescheduleBean.prepareReschedule(aptmnt.appointmentId)}"
+                              process="@this"
+                              rendered="#{aptmnt.status.toString() == 'SCHEDULED'}"
+                              update=":pageContentForm:mainContentPanel"
+                              styleClass="ui-button-warning mr-2" >
+                     <p:confirm header="Confirmation" message="Are you sure you want to reschedule?" icon="pi pi-exclamation-triangle"/>
+                  </p:menuitem>
+
+                  <p:menuitem value="Cancel"
+                              icon="pi pi-times"
+                              title="Cancel Appointment"
+                              process="@this"
+                              update="appointmentTable appointmentMessages"
+                              action="#{appointmentListBean.cancelAppointment(aptmnt)}"
+                              styleClass="ui-button-secondary"
+                              rendered="#{aptmnt.status.toString() != 'CANCELLED' and aptmnt.status.toString() != 'COMPLETED'}">
+                     <p:confirm header="Confirmation" message="Are you sure you want to reschedule?" icon="pi pi-exclamation-triangle"/>
+                  </p:menuitem>
+               </p:menuButton>
             </p:column>
 
          </p:dataTable>

--- a/src/main/webapp/template.xhtml
+++ b/src/main/webapp/template.xhtml
@@ -27,7 +27,7 @@
             border-radius: 6px;
             transition: background-color 0.2s, color 0.2s;
             font-weight: 500;
-            color: gainsboro; /* Use a theme variable for text color */
+            color: white !important; /* Use a theme variable for text color */
         }
         .menu-link:hover {
             background-color: var(--blue-600); /* Use a theme variable for hover */
@@ -131,7 +131,7 @@
                                    update=":pageContentForm:mainContentPanel :menuForm"
                                    styleClass="menu-link #{pageNavigationBean.selectedMenu == 'unpaid_bills' ? 'menu-link-active' : ''}" />
 
-                    <p:commandLink value="Completed Appointments"
+                    <p:commandLink value="Appointments"
                                    icon="pi pi-check-square"
                                    action="#{pageNavigationBean.navigateToCompletedAppointments}"
                                    rendered="#{userAccountBean.isReceptionist()}"


### PR DESCRIPTION
### What does this pull request do?
This pull request introduces a feature that allows the receptionist to view all appointments and be able to reschedule or cancel them based on the status of the selected appointment. And also introduce redirect on when admin is on patient list or staff list and they click on add new staff or patient and they are redirected.
### Description of the task completed.
In order to achieve this i changed the method that returns the list of all completed appointments and made it return all appointments, Then updated the view that displays the list to include buttons that will allow to cancel or reschedule. They appear only when the status of the appointment matches the rendered condition.
Also updated the query that returns the list to do lazy fetch on the patient , doctor and bill associated to the appointment.
Updated the commandButton component's process tag to content the keyword "this" so that it actually redirects when the button is clicked. 
### How could this be manually test?
To test this feature we need to login as a receptionist and navigate to the page that contains the list of appointments the under action, buttons should be displayed based on the status of the appointment and one should be able to either reschedule or cancel.
To test the redirect to new staff or new patient page, we need to login as an admin then navigate to patient list or staff list page then click or add staff or add patient button to be redirected to new staff or new patient form.