### PR TITLE
Refactor Staff Registration to Dialog and Add Registration Date

### DIFF
--- a/src/main/java/org/pahappa/systems/hms/models/Staff.java
+++ b/src/main/java/org/pahappa/systems/hms/models/Staff.java
@@ -58,6 +58,8 @@ public class Staff {
     @Column(name = "available_date_time")
     @OrderBy("available_date_time ASC") // Keep them sorted
     private Set<LocalDateTime> availableSlots = new HashSet<>(); // Use Set for uniqueness
+    @Column(name = "registration_date")
+    private LocalDateTime registrationDate;
 
     // Constructors
     public Staff() {
@@ -75,6 +77,7 @@ public class Staff {
         this.dateOfBirth = dateOfBirth; // Changed to Date
         this.gender = gender;
         this.deleted = false;
+        this.registrationDate = LocalDateTime.now();
     }
 
     // Getters and Setters
@@ -112,6 +115,14 @@ public class Staff {
         return availableSlots;
     }
 
+    public LocalDateTime getRegistrationDate() {
+        return registrationDate;
+    }
+
+    public void setRegistrationDate(LocalDateTime registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
     public void setAvailableSlots(Set<LocalDateTime> availableSlots) {
         this.availableSlots = availableSlots;
     }
@@ -130,19 +141,4 @@ public class Staff {
         return this.availableSlots.remove(slot);
     }
 
-    // toString method (mostly fine, adjust department display if needed)
-    @Override
-    public String toString() {
-        String lineSeparator = System.lineSeparator();
-        int labelWidth = 18;
-        StringBuilder sb = new StringBuilder();
-        sb.append("--------------------------------------").append(lineSeparator);
-        sb.append(String.format("%-" + labelWidth + "s: %s%n", "Staff Member", getName() != null ? getName() : "N/A"));
-        sb.append(String.format("%-" + labelWidth + "s: %s%n", "Staff ID", staffId != null ? staffId : "N/A")); // Consistent label
-        sb.append(String.format("%-" + labelWidth + "s: %s%n", "Role", getRole() != null ? getRole().toString() : "N/A"));
-        sb.append(String.format("%-" + labelWidth + "s: %s%n", "Department",
-                department != null ? (department.getDisplayName() != null ? department.getDisplayName() : department.name()) : "N/A")); // Safer department display
-        sb.append("--------------------------------------").append(lineSeparator);
-        return sb.toString();
-    }
 }

--- a/src/main/java/views/admin/StaffBean.java
+++ b/src/main/java/views/admin/StaffBean.java
@@ -111,7 +111,6 @@ public class StaffBean implements Serializable {
                     new FacesMessage(FacesMessage.SEVERITY_INFO, "Success", "Staff member " + registeredStaffOpt.get().getName() + " registered successfully."));
             init(); // Reset the form fields for the next entry
             staffListBean.refreshList();
-            pageNavigationBean.navigateToViewStaff();
         } else {
             FacesContext.getCurrentInstance().addMessage(null,
                     new FacesMessage(FacesMessage.SEVERITY_ERROR, "Registration Failed", "Could not register staff. The username or email might already be in use."));

--- a/src/main/java/views/admin/StaffListBean.java
+++ b/src/main/java/views/admin/StaffListBean.java
@@ -12,6 +12,7 @@ import org.pahappa.systems.hms.services.impl.StaffServiceImpl;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Named("staffListBean")
@@ -37,14 +38,19 @@ public class StaffListBean implements Serializable {
 
     private void loadStaff() {
         staffList = staffService.getAllStaffs();
+
         if (staffList == null) {
             staffList = new ArrayList<>();
             System.err.println("StaffListBean: hospitalService.getAllStaffs() returned null.");
         } else {
+            // Sort by registration date descending
+            staffList.sort(Comparator.comparing(Staff::getRegistrationDate).reversed());
             System.out.println("StaffListBean: Loaded " + staffList.size() + " staff members.");
         }
+
         this.filteredStaffList = new ArrayList<>(this.staffList);
     }
+
 
     public List<Staff> getStaffList() {
         return staffList;

--- a/src/main/webapp/WEB-INF/includes/admin/staff_list.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/staff_list.xhtml
@@ -26,8 +26,11 @@
             <f:facet name="header">
                 <div class="flex justify-content-between align-items-center">
                     <p:commandButton value="Add New Staff" icon="pi pi-plus"
-                                     action="#{pageNavigationBean.navigateAddNewStaff}"
-                                     update=":pageContentForm:mainContentPanel" process="@this"/>
+
+                    update="@widgetVar(staffRegDialogWidget)"
+                    oncomplete="PF('staffRegDialogWidget').show()"
+                    process="@this"
+                    styleClass="ui-button-success"/>
 
                     <!-- This is the global filter input -->
                     <span class="p-input-icon-left">
@@ -41,8 +44,7 @@
                 </div>
             </f:facet>
 
-            <!-- For each column you want to be part of the search, add globalFilter="true" -->
-            <!-- The filterBy attribute on the column is for individual column filtering, not global -->
+
 
             <p:column headerText="Full Name" sortBy="#{staff.name}" globalFilter="true">
                 <h:outputText value="#{staff.name}" />

--- a/src/main/webapp/WEB-INF/includes/admin/staff_registration.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/staff_registration.xhtml
@@ -4,138 +4,150 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:ui="jakarta.faces.facelets">
 
-    <p:card header="Register New Staff Member" styleClass="shadow-2 border-round-lg" style="padding:2rem;">
-        <h:form id="staffRegForm" styleClass="p-fluid floatlabel-demo">
+    <p:dialog header="Register New Staff Member"
+              widgetVar="staffRegDialogWidget"
+              id="staffRegDialog"
+              modal="true"
+              closable="true"
+              resizable="false"
+              draggable="false"
+              appendTo="@(body)"
+              showEffect="fade"
+              hideEffect="fade"
+              styleClass="p-fluid"
+              style="width: 60vw; max-width: 900px;">
 
-            <p:growl id="successMessage" showDetail="true" closable="true" />
+        <h:form id="staffRegForm">
+            <p:messages id="regMessages" showDetail="true" closable="true" />
 
-            <!-- Account Credentials -->
-            <p:fieldset legend="Account" styleClass="mb-4">
-                <div class="formgrid grid">
-                    <div class="field col-12 md:col-6">
-                        <span class="ui-float-label">
-                            <p:inputText id="username" value="#{staffBean.username}" required="true"
-                                         requiredMessage="Username is required." />
-                            <p:outputLabel for="@previous" value="Username" />
-                        </span>
-                        <p:message for="username"/>
-                    </div>
-                    <div class="field col-12 md:col-6">
-                        <span class="ui-float-label">
-                            <p:password id="password" value="#{staffBean.password}" required="true"
-                                        toggleMask="true" redisplay="true" feedback="true"
-                                        requiredMessage="Password is required." />
-                            <p:outputLabel for="@previous" value="Password" />
-                        </span>
-                        <p:message for="password"/>
-                    </div>
-                </div>
-            </p:fieldset>
+            <p:outputPanel id="staffRegDialogContent" styleClass="mt-3">
 
-            <!-- Personal Information -->
-            <p:fieldset legend="Personal Info" styleClass="mb-4">
-                <div class="formgrid grid">
-                    <div class="field col-12 md:col-6">
-                        <span class="ui-float-label">
-                            <p:inputText id="fullName" value="#{staffBean.fullName}" required="true"
-                                         requiredMessage="Full name is required." />
-                            <p:outputLabel for="@previous" value="Full Name" />
-                        </span>
-                        <p:message for="fullName"/>
+                <!-- Account Section -->
+                <p:fieldset legend="Account" toggleable="true" toggleSpeed="150" styleClass="mb-3">
+                    <div class="formgrid grid">
+                        <div class="field col-12 md:col-6">
+                            <span class="ui-float-label">
+                                <p:inputText id="username" value="#{staffBean.username}" required="true"
+                                             requiredMessage="Username is required." />
+                                <p:outputLabel for="@previous" value="Username" />
+                            </span>
+                            <p:message for="username"/>
+                        </div>
+                        <div class="field col-12 md:col-6">
+                            <span class="ui-float-label">
+                                <p:password id="password" value="#{staffBean.password}" required="true"
+                                            toggleMask="true" redisplay="true" feedback="false"
+                                            requiredMessage="Password is required." />
+                                <p:outputLabel for="@previous" value="Password" />
+                            </span>
+                            <p:message for="password"/>
+                        </div>
                     </div>
-                    <div class="field col-12 md:col-6">
-                        <span class="ui-float-label">
-                            <p:inputText id="email" value="#{staffBean.email}" type="email" required="true"
-                                         requiredMessage="Email is required.">
-                                <f:validateBean />
-                            </p:inputText>
-                            <p:outputLabel for="@previous" value="Email" />
-                        </span>
-                        <p:message for="email"/>
-                    </div>
+                </p:fieldset>
 
-                    <div class="field col-12 md:col-6">
-                        <span class="ui-float-label">
-                            <p:inputMask id="phone" value="#{staffBean.phone}" mask="999 999 9999">
-                                <f:validator validatorId="custom.ugandanPhoneValidator" />
-                            </p:inputMask>
-                            <p:outputLabel for="@previous" value="Phone" />
-                        </span>
-                        <p:message for="phone"/>
+                <!-- Personal Info Section -->
+                <p:fieldset legend="Personal Info" toggleable="true" toggleSpeed="150" styleClass="mb-3">
+                    <div class="formgrid grid">
+                        <div class="field col-12 md:col-6">
+                            <span class="ui-float-label">
+                                <p:inputText id="fullName" value="#{staffBean.fullName}" required="true"
+                                             requiredMessage="Full name is required." />
+                                <p:outputLabel for="@previous" value="Full Name" />
+                            </span>
+                            <p:message for="fullName"/>
+                        </div>
+                        <div class="field col-12 md:col-6">
+                            <span class="ui-float-label">
+                                <p:inputText id="email" value="#{staffBean.email}" type="email" required="true"
+                                             requiredMessage="Email is required.">
+                                    <f:validateBean/>
+                                </p:inputText>
+                                <p:outputLabel for="@previous" value="Email" />
+                            </span>
+                            <p:message for="email"/>
+                        </div>
+                        <div class="field col-12 md:col-6">
+                            <span class="ui-float-label">
+                                <p:inputMask id="phone" value="#{staffBean.phone}" mask="999 999 9999">
+                                    <f:validator validatorId="custom.ugandanPhoneValidator" />
+                                </p:inputMask>
+                                <p:outputLabel for="@previous" value="Phone" />
+                            </span>
+                            <p:message for="phone"/>
+                        </div>
+                        <div class="field col-12 md:col-6">
+                            <p:outputLabel for="dob" value="Date of Birth" styleClass="mb-1 block" />
+                            <p:datePicker id="dob"
+                                          value="#{staffBean.birthday}"
+                                          monthNavigator="true"
+                                          yearNavigator="true"
+                                          showIcon="true"
+                                          pattern="MM/dd/yyyy"
+                                          yearRange="c-100:c"
+                                          styleClass="w-full" />
+                            <p:message for="dob"/>
+                        </div>
+                        <div class="field col-12">
+                            <span class="ui-float-label">
+                                <p:inputTextarea id="address" value="#{staffBean.address}" rows="2" autoResize="true" />
+                                <p:outputLabel for="@previous" value="Address" />
+                            </span>
+                            <p:message for="address"/>
+                        </div>
+                        <div class="field col-12">
+                            <p:outputLabel for="gender" value="Gender" />
+                            <p:selectOneRadio id="gender" value="#{staffBean.gender}" layout="lineDirection">
+                                <f:selectItem itemLabel="Male" itemValue="Male" />
+                                <f:selectItem itemLabel="Female" itemValue="Female" />
+                            </p:selectOneRadio>
+                            <p:message for="gender"/>
+                        </div>
                     </div>
+                </p:fieldset>
 
-                    <div class="field col-12 md:col-6">
-                        <p:outputLabel for="dob" value="Date of Birth" styleClass="mb-1 block" />
-                        <p:datePicker id="dob"
-                                      value="#{staffBean.birthday}"
-                                      monthNavigator="true"
-                                      yearNavigator="true"
-                                      showIcon="true"
-                                      pattern="MM/dd/yyyy"
-                                      yearRange="c-100:c"
-                                      styleClass="w-full" />
-                        <p:message for="dob"/>
+                <!-- Professional Info Section -->
+                <p:fieldset legend="Professional Info" toggleable="true" toggleSpeed="150" styleClass="mb-3">
+                    <div class="formgrid grid">
+                        <div class="field col-12 md:col-6">
+                            <span class="ui-float-label">
+                                <p:selectOneMenu id="role" value="#{staffBean.role}" required="true"
+                                                 requiredMessage="Role is required.">
+                                    <f:selectItem itemValue="#{null}" noSelectionOption="true" itemLabel="--- Select Role ---"/>
+                                    <f:selectItems value="#{staffBean.availableRoles}" var="r" itemLabel="#{r}" itemValue="#{r}" />
+                                </p:selectOneMenu>
+                                <p:outputLabel for="@previous" value="Role" />
+                            </span>
+                            <p:message for="role"/>
+                        </div>
+                        <div class="field col-12 md:col-6">
+                            <span class="ui-float-label">
+                                <p:selectOneMenu id="department" value="#{staffBean.department}" required="true"
+                                                 requiredMessage="Department is required.">
+                                    <f:selectItem itemValue="#{null}" noSelectionOption="true" itemLabel="--- Select Department ---"/>
+                                    <f:selectItems value="#{staffBean.availableDepartments}" var="d" itemLabel="#{d.displayName}" itemValue="#{d}" />
+                                </p:selectOneMenu>
+                                <p:outputLabel for="@previous" value="Department" />
+                            </span>
+                            <p:message for="department"/>
+                        </div>
                     </div>
+                </p:fieldset>
 
+            </p:outputPanel>
 
-                    <div class="field col-12">
-                        <span class="ui-float-label">
-                            <p:inputTextarea id="address" value="#{staffBean.address}" rows="2" autoResize="true" />
-                            <p:outputLabel for="@previous" value="Address" />
-                        </span>
-                        <p:message for="address"/>
-                    </div>
-
-                    <div class="field col-12">
-                        <p:outputLabel for="gender" value="Gender" />
-                        <p:selectOneRadio id="gender" value="#{staffBean.gender}" layout="lineDirection">
-                            <f:selectItem itemLabel="Male" itemValue="Male" />
-                            <f:selectItem itemLabel="Female" itemValue="Female" />
-                        </p:selectOneRadio>
-                        <p:message for="gender"/>
-                    </div>
-                </div>
-            </p:fieldset>
-
-            <!-- Professional Info -->
-            <p:fieldset legend="Professional Info" styleClass="mb-4">
-                <div class="formgrid grid">
-                    <div class="field col-12 md:col-6">
-                        <span class="ui-float-label">
-                            <p:selectOneMenu id="role" value="#{staffBean.role}" required="true"
-                                             requiredMessage="Role is required.">
-                                <f:selectItem  itemValue="#{null}" noSelectionOption="true" />
-                                <f:selectItems value="#{staffBean.availableRoles}" var="role"
-                                               itemLabel="#{role}" itemValue="#{role}" />
-                            </p:selectOneMenu>
-                            <p:outputLabel for="@previous" value="Role" />
-                        </span>
-                        <p:message for="role"/>
-                    </div>
-                    <div class="field col-12 md:col-6">
-                        <span class="ui-float-label">
-                            <p:selectOneMenu id="department" value="#{staffBean.department}" required="true"
-                                             requiredMessage="Department is required.">
-                                <f:selectItem itemValue="#{null}" noSelectionOption="true" />
-                                <f:selectItems value="#{staffBean.availableDepartments}" var="dept"
-                                               itemLabel="#{dept.displayName}" itemValue="#{dept}" />
-                            </p:selectOneMenu>
-                            <p:outputLabel for="@previous" value="Department" />
-                        </span>
-                        <p:message for="department"/>
-                    </div>
-                </div>
-            </p:fieldset>
-
-            <!-- Buttons -->
-            <div class="flex gap-2 justify-content-end mt-3">
-                <p:commandButton value="Register" icon="pi pi-check" styleClass="ui-button-success"
-                                 process="@form" action="#{staffBean.register()}"
-                                 update="@form successMessage" />
-                <p:commandButton type="reset" value="Clear" icon="pi pi-times" styleClass="ui-button-secondary" />
+            <!-- Dialog Buttons -->
+            <div class="flex justify-content-end gap-2 mt-3">
+                <p:commandButton value="Cancel" type="button" icon="pi pi-times"
+                                 onclick="PF('staffRegDialogWidget').hide()"
+                                 styleClass="ui-button-secondary" />
+                <p:commandButton value="Register Staff" icon="pi pi-check"
+                                 action="#{staffBean.register}"
+                                 process="@form"
+                                 update="regMessages :staffListForm:staffTable"
+                                 oncomplete="if (args &amp;&amp; !args.validationFailed) PF('staffRegDialogWidget').hide();"
+                                 styleClass="ui-button-success" />
             </div>
 
         </h:form>
-    </p:card>
-
+    </p:dialog>
 </ui:composition>


### PR DESCRIPTION
### What does this PR do?
This pull request significantly improves the staff management user experience. It refactors the "Add New Staff" feature from a separate page into a modal dialog, allowing administrators to add staff without leaving the main staff list view. Additionally, it adds a registrationDate to the Staff entity and the dataTable, enabling sorting by when a staff member was added.
### Description of Task to be completed?
1. Staff Registration Dialog:
The staff_registration.xhtml content has been converted into a reusable dialog fragment (staff_registration_dialog.xhtml).
The "Add New Staff" button on the staff list page no longer navigates away. Instead, it now uses an actionListener (#{staffBean.prepareNewStaff}) to reset the form bean and then opens the registration dialog via oncomplete="PF('staffRegDialogWidget').show()".
The "Register" button inside the dialog now uses AJAX (process="staffRegForm") to submit the new staff details.
Upon successful registration, the dialog closes automatically, and the main staff list dataTable is updated via AJAX to instantly show the newly added member. A success message is displayed in a global growl.
If validation fails within the dialog, error messages are shown inline, and the dialog remains open for the user to correct the input.
2. Added registrationDate to Staff Entity:
A new field private Date registrationDate; has been added to the models.Staff entity, annotated with @Temporal(TemporalType.TIMESTAMP).
The Staff constructor is updated to set this field to new Date() upon object creation, effectively timestamping the registration.
This new field is now persisted to the database.
3. Enhanced Staff List View:
A new "Date Registered" column has been added to the p:dataTable in staff_list_content.xhtml.
This column is sortable (sortBy="#{staff.registrationDate}") and uses <f:convertDateTime> for user-friendly date formatting.
### How should this be manually tested?

- Test Case 1: Add New Staff via Dialog

Log in as an Administrator.
Navigate to the "Manage Staff" page.
Click the "Add New Staff" button.
Expected Result: A modal dialog should appear with a blank form for registering a new staff member.
Fill out the form with valid details and click "Register Staff".
Expected Result:
The dialog should close.
A "Success" message should appear.
The dataTable should refresh, and the newly added staff member should be visible at the top or bottom of the list.
Attempt to submit the form with invalid data (e.g., empty required field).
Expected Result: The dialog should remain open, and validation error messages should appear inside the dialog next to the relevant fields.

- Test Case 2: Sort by Registration Date

On the "Manage Staff" page, locate the "Date Registered" column header in the dataTable.
Click the header to sort the list.
Expected Result: The staff list should sort correctly by date, ascending or descending, allowing the administrator to easily see the most recently added staff members.
### Any background context you want to provide?
This refactoring streamlines the administrator's workflow by using a dialog instead of requiring page navigation for a common task. The addition of the registrationDate provides valuable metadata and improves the data management capabilities of the staff list view. This work also fixes previous AJAX state issues by adopting a more robust pattern for dialog interaction.