### PR TITLE
 Refactor patient registration form into a modal dialog

### DIFF
--- a/src/main/java/org/pahappa/systems/hms/navigation/PageNavigationBean.java
+++ b/src/main/java/org/pahappa/systems/hms/navigation/PageNavigationBean.java
@@ -28,7 +28,7 @@ public class PageNavigationBean implements Serializable {
             } else if (userAccountBean.isPatient()) {
                 navigateToPatientAppointments();
             } else if (userAccountBean.isReceptionist()) {
-                navigateAddNewPatient();
+                navigateToViewPatients();
             } else if (userAccountBean.isAccountant()) {
                 navigateToDashboard();
             } else {

--- a/src/main/java/views/patient/PatientBean.java
+++ b/src/main/java/views/patient/PatientBean.java
@@ -138,7 +138,7 @@ public class PatientBean implements Serializable {
         System.out.println("Attempting to register staff: " + this.fullName);
         Optional<Patient> registeredPatientOpt = patientService.registerPatient(
                 this.username,
-                this.password, // SEND HASHED PASSWORD TO SERVICE
+                this.password,
                 this.fullName,
                 birthday,
                 this.address,

--- a/src/main/webapp/WEB-INF/includes/admin/patient_list.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/patient_list.xhtml
@@ -29,14 +29,14 @@
                 <f:facet name="header">
                     <div class="flex justify-content-between align-items-center">
                         <p:commandButton value="Add New Patient" icon="pi pi-plus"
-                                         action="#{pageNavigationBean.navigateAddNewPatient()}"
-                                         update=":pageContentForm:mainContentPanel" process="@this"/>
+                                         oncomplete="PF('patientRegisterDialog').show()"
+                                          process="@this"/>
 
                         <!-- This is the global filter input -->
                         <span class="p-input-icon-left">
                            <p:inputText id="globalFilter"
                                         placeholder="Search all fields..."
-                                        onkeyup="PrimeFaces.debounce(() => PF('staffTableWidget').filter(), 300)"
+                                        onkeyup="PrimeFaces.debounce(() => PF('patientTableWidget').filter(), 300)"
                                         style="width: 20rem;" />
 
                         </span>
@@ -78,6 +78,7 @@
                                     oncomplete="PF('userDetailDialogWidget').show()" />
 
                         <p:menuitem value="#{patient.deleted ? 'Re-activate' : 'Deactivate'}"
+                                    rendered="#{userAccountBean.isAdministrator()}"
                                     icon="#{patient.deleted ? 'pi pi-undo' : 'pi pi-trash'}"
                                     styleClass="#{patient.deleted ? '' : 'ui-menuitem-danger'}"
                                     actionListener="#{patientListBean.deletePatient(patient)}"

--- a/src/main/webapp/WEB-INF/includes/receptionist/patient_registration.xhtml
+++ b/src/main/webapp/WEB-INF/includes/receptionist/patient_registration.xhtml
@@ -4,8 +4,19 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:ui="jakarta.faces.facelets">
 
-   <p:card header="Register Patient" styleClass="shadow-1" style="padding:1rem;">
-      <h:form id="staffRegForm" styleClass="p-fluid">
+   <!-- Register Patient Dialog -->
+   <p:dialog header="Register Patient"
+             widgetVar="patientRegisterDialog"
+             modal="true"
+             closable="true"
+             draggable="false"
+             resizable="false"
+             showEffect="fade"
+             hideEffect="fade"
+             styleClass="shadow-2"
+             width="50vw">
+
+      <h:form id="patientRegForm" styleClass="p-fluid">
 
          <p:growl id="message" showDetail="true" />
 
@@ -35,7 +46,6 @@
          <!-- Personal Info -->
          <p:fieldset legend="Personal Info" toggleable="false" styleClass="mb-3">
             <div class="formgrid grid">
-
                <div class="field col-12 md:col-6">
                   <p:outputLabel for="fullName" value="Full Name" styleClass="mb-1 block" />
                   <p:inputText id="fullName" value="#{patientBean.fullName}" required="true"
@@ -54,7 +64,7 @@
 
                <div class="field col-12 md:col-6">
                   <p:outputLabel for="phone" value="Phone" styleClass="mb-1 block" />
-                  <p:inputMask id="phone" value="#{staffBean.phone}" mask="999 999 9999">
+                  <p:inputMask id="phone" value="#{patientBean.phone}" mask="999 999 9999">
                      <f:validator validatorId="custom.ugandanPhoneValidator" />
                   </p:inputMask>
                   <p:message for="phone" />
@@ -94,14 +104,15 @@
          <div class="flex gap-2 justify-content-end mt-3">
             <p:commandButton value="Register" icon="pi pi-check"
                              action="#{patientBean.register}"
-                             update="@form message"
                              process="@form"
-                             oncomplete="#{pageNavigationBean.navigateToViewPatients()}"
+                             update=":pageContentForm:patientListForm:patientTable :pageContentForm:patientListForm:growl"
+                             oncomplete="if (!args.validationFailed) PF('patientRegisterDialog').hide();"
                              styleClass="ui-button-success" />
+
 
             <p:commandButton value="Clear" type="reset" icon="pi pi-times" styleClass="ui-button-secondary" />
          </div>
 
       </h:form>
-   </p:card>
+   </p:dialog>
 </ui:composition>

--- a/src/main/webapp/template.xhtml
+++ b/src/main/webapp/template.xhtml
@@ -135,12 +135,6 @@
                                    styleClass="menu-link #{pageNavigationBean.selectedMenu == 'doctor_appointment_list' ? 'menu-link-active' : ''}" />
 
                     <!-- Receptionist Links -->
-                    <p:commandLink value="Register Patient"
-                                   icon="pi pi-user-plus"
-                                   action="#{pageNavigationBean.navigateAddNewPatient}"
-                                   rendered="#{userAccountBean.isReceptionist()}"
-                                   update=":pageContentForm:mainContentPanel :menuForm"
-                                   styleClass="menu-link #{pageNavigationBean.selectedMenu == 'patientRegistration' ? 'menu-link-active' : ''}" />
 
                     <p:commandLink value="Appointments"
                                    icon="pi pi-check-square"
@@ -173,7 +167,7 @@
                     <p:commandLink value="Manage Patients"
                                    icon="pi pi-user-edit"
                                    action="#{pageNavigationBean.navigateToViewPatients}"
-                                   rendered="#{userAccountBean.isAdministrator()}"
+                                   rendered="#{userAccountBean.isAdministrator() or userAccountBean.isReceptionist()}"
                                    update=":pageContentForm:mainContentPanel :menuForm"
                                    styleClass="menu-link #{pageNavigationBean.selectedMenu == 'patient_list' ? 'menu-link-active' : ''}" />
 
@@ -269,7 +263,7 @@
     <ui:include src="/WEB-INF/includes/dialogs/medication_dialog.xhtml"/>
     <ui:include src="/WEB-INF/includes/dialogs/prescription_payment.xhtml"/>
     <ui:include src="/WEB-INF/includes/dialogs/reciept_dialog.xhtml"/>
-
+    <ui:include src="/WEB-INF/includes/receptionist/patient_registration.xhtml"/>
 
 </h:body>
 </html>


### PR DESCRIPTION
### What does this PR do?
This pull request refactors the "Register Patient" feature from a dedicated page/view into a modal dialog. This allows users (like Receptionists) to add new patients without leaving their current context, such as the main patient list or dashboard, significantly improving workflow and user experience.
### Description of Task to be completed?

- Dialog Conversion:

The content of the patient_registration.xhtml fragment has been wrapped in a <p:dialog> component.
The dialog is configured with widgetVar="patientRegDialogWidget", is modal, and uses appendTo="@(body)" for proper DOM placement.

- Trigger Button:

A new "Register Patient" p:commandButton has been added to the appropriate view (e.g., the Receptionist's main page or the "Manage Patients" view).
This button's actionListener now calls #{patientBean.prepareNewPatient} to reset the form fields in the backing bean.
The button's oncomplete script calls PF('patientRegDialogWidget').show() to open the dialog after the bean has been prepared.

- AJAX Form Submission:

The "Register" button inside the new dialog now uses AJAX (process="patientRegForm") to submit the form data.
On successful registration, the dialog closes automatically (oncomplete script), a success message is displayed via <p:growl>, and the main patient list on the underlying page is updated via the button's update attribute to show the newly added patient instantly.
### How should this be manually tested?
Log in as a user with patient registration permissions (e.g., a Receptionist).
Navigate to the page where the "Register Patient" button is located (e.g., the "Manage Patients" list).
Click the "Register Patient" button.

- Expected Result: A modal dialog should appear with a blank form for registering a new patient.

Fill out the form with valid patient details and click the "Register" button inside the dialog.

- Expected Result:

The dialog should close.
A "Success" message should appear (e.g., in a corner growl).
The main patient list on the page should refresh and display the newly added patient.
Attempt to submit the form with invalid data (e.g., an empty required field).

- Expected Result: The dialog should remain open, and validation error messages should appear inside the dialog, prompting the user for corrections.

### Any background context you want to provide?
This change streamlines the patient registration workflow, making it faster and more intuitive for front-desk staff. It replaces a full-page navigation with a more modern, single-page-application (SPA) style interaction for this common task.