### PR TITLE
Updated the medication admin bean and service catalog admin and the u…

### DIFF
--- a/src/main/java/views/admin/MedicationAdminBean.java
+++ b/src/main/java/views/admin/MedicationAdminBean.java
@@ -9,6 +9,7 @@ import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.pahappa.systems.hms.models.Medication;
+import org.pahappa.systems.hms.models.ServiceCatalogItem;
 import org.pahappa.systems.hms.services.PharmacyService;
 
 
@@ -26,6 +27,7 @@ public class MedicationAdminBean implements Serializable {
     private PharmacyService pharmacyService;
 
     private List<Medication> allMedications;
+    private List<Medication> filteredMedications;
     private Medication selectedMedication; // For editing or adding
     private boolean is_New = true; // To distinguish between add and edit mode in the dialog
 
@@ -38,12 +40,26 @@ public class MedicationAdminBean implements Serializable {
     private void loadAllMedications() {
         if (pharmacyService != null) {
             allMedications = pharmacyService.getFullMedicationCatalog();
+            this.filteredMedications = new ArrayList<>(allMedications);
         } else {
             allMedications = new ArrayList<>();
             System.err.println("MedicationAdminBean: PharmacyService not injected.");
         }
     }
 
+
+    public boolean globalFilterFunction(Object value, Object filter, java.util.Locale locale) {
+        String filterText = (filter == null) ? "" : filter.toString().toLowerCase();
+        if (filterText.isBlank()) return true;
+
+        Medication medication = (Medication) value;
+
+        return (medication.getName() != null && medication.getName().toLowerCase().contains(filterText)) ||
+                (medication.getDescription() != null && medication.getDescription().toLowerCase().contains(filterText)) ||
+                (medication.getMedicationId() <= 0 && medication.getMedicationId() > 0);
+
+
+    }
     // Prepares the dialog for adding a NEW medication
     public void openNew() {
         this.selectedMedication = new Medication(); // Create a new blank instance
@@ -103,6 +119,15 @@ public class MedicationAdminBean implements Serializable {
     }
 
     // Getters and Setters
+
+    public List<Medication> getFilteredMedications() {
+        return filteredMedications;
+    }
+
+    public void setFilteredMedications(List<Medication> filteredMedications) {
+        this.filteredMedications = filteredMedications;
+    }
+
     public List<Medication> getAllMedications() {
         return allMedications;
     }

--- a/src/main/java/views/admin/ServiceCatalogAdminBean.java
+++ b/src/main/java/views/admin/ServiceCatalogAdminBean.java
@@ -6,6 +6,7 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Named;
 import jakarta.validation.constraints.Min;
+import org.pahappa.systems.hms.models.Patient;
 import org.pahappa.systems.hms.models.ServiceCatalogItem;
 import org.pahappa.systems.hms.constants.ServiceCategory; // Your enum
 
@@ -24,6 +25,7 @@ public class ServiceCatalogAdminBean implements Serializable {
     private final ServiceCatalogServiceImpl  serviceCatalogService;
 
     private List<ServiceCatalogItem> catalogItems; // To display existing items
+    private List<ServiceCatalogItem> filteredCatalogItems;
 
     // Fields for adding a new service
     private String newServiceCode;
@@ -52,6 +54,7 @@ public class ServiceCatalogAdminBean implements Serializable {
         if (catalogItems == null) {
             catalogItems = new ArrayList<>();
         }
+        this.filteredCatalogItems = new ArrayList<>(catalogItems);
     }
 
     private void resetNewServiceForm() {
@@ -63,6 +66,19 @@ public class ServiceCatalogAdminBean implements Serializable {
         newServiceActive = true;
     }
 
+
+    // ✅ Global Filter Function
+    public boolean globalFilterFunction(Object value, Object filter, java.util.Locale locale) {
+        String filterText = (filter == null) ? "" : filter.toString().toLowerCase();
+        if (filterText.isBlank()) return true;
+
+        ServiceCatalogItem serviceCatalogItem = (ServiceCatalogItem) value;
+
+        return (serviceCatalogItem.getName() != null && serviceCatalogItem.getName().toLowerCase().contains(filterText)) ||
+                (serviceCatalogItem.getServiceCode() != null && serviceCatalogItem.getServiceCode().toLowerCase().contains(filterText)) ||
+                (serviceCatalogItem.getCategory().toString() != null && serviceCatalogItem.getCategory().toString().toLowerCase().contains(filterText)) ||
+                (serviceCatalogItem.getDescription() != null && serviceCatalogItem.getDescription().toLowerCase().contains(filterText));
+    }
     public void addNewServiceCatalogItem() {
         FacesContext context = FacesContext.getCurrentInstance();
         // Basic Validation
@@ -149,6 +165,15 @@ public class ServiceCatalogAdminBean implements Serializable {
 
 
     // Getters and Setters
+
+    public List<ServiceCatalogItem> getFilteredCatalogItems() {
+        return filteredCatalogItems;
+    }
+
+    public void setFilteredCatalogItems(List<ServiceCatalogItem> filteredCatalogItems) {
+        this.filteredCatalogItems = filteredCatalogItems;
+    }
+
     public List<ServiceCatalogItem> getCatalogItems() { return catalogItems; }
     public String getNewServiceCode() { return newServiceCode; }
     public void setNewServiceCode(String newServiceCode) { this.newServiceCode = newServiceCode; }

--- a/src/main/webapp/WEB-INF/includes/admin/manage_medication_catalog_content.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/manage_medication_catalog_content.xhtml
@@ -6,30 +6,45 @@
 
    <p:panel header="Manage Medication Catalog">
       <h:form id="medicationCatalogForm">
-         <p:messages id="medicationMessages" showDetail="true" closable="true" autoUpdate="true"/>
+         <p:growl id="medicationMessages" showDetail="true" closable="true" life="2000" autoUpdate="true"/>
 
-         <p:toolbar>
-            <p:toolbarGroup>
-               <p:commandButton value="New Medication" icon="pi pi-plus"
-                                action="#{medicationAdminBean.openNew()}"
-                                oncomplete="PF('medicationDialogWidget').show()"
-                                process="@this"
-                                update="@widgetVar(medicationDialogWidget)"
-               styleClass="ui-button-success"/>
-            </p:toolbarGroup>
-         </p:toolbar>
-
-         <p:dataTable id="medicationTable" var="med" value="#{medicationAdminBean.allMedications}"
+         <p:dataTable id="medicationTable"
+                      widgetVar="medicationWidget" var="med" value="#{medicationAdminBean.allMedications}"
+                      globalFilterFunction="#{medicationAdminBean.globalFilterFunction}"
+                      filteredValue="#{medicationAdminBean.filteredMedications}"
+                      paginatorPosition="bottom"
                       paginator="true" rows="10" emptyMessage="No medications found in catalog."
                       reflow="true" style="margin-top:10px;">
 
-            <p:column headerText="ID" sortBy="#{med.medicationId}" style="width:5%;">
+            <!-- The header now contains the global filter input box -->
+            <f:facet name="header">
+               <div class="flex justify-content-between align-items-center">
+                  <p:commandButton value="New Medication" icon="pi pi-plus"
+                                   action="#{medicationAdminBean.openNew()}"
+                                   oncomplete="PF('medicationDialogWidget').show()"
+                                   process="@this"
+                                   update="@widgetVar(medicationDialogWidget)"
+                                   styleClass="ui-button-success"/>
+                  <!-- This is the global filter input -->
+                  <span class="p-input-icon-left">
+                           <p:inputText id="globalFilter"
+                                        placeholder="Search all fields..."
+                                        onkeyup="PrimeFaces.debounce(() => PF('medicationWidget').filter(), 300)"
+                                        style="width: 20rem;" />
+
+                        </span>
+               </div>
+            </f:facet>
+
+            <p:column headerText="ID" sortBy="#{med.medicationId}"
+                      globalFilter="true"
+                      style="width:5%;">
                <h:outputText value="#{med.medicationId}"/>
             </p:column>
-            <p:column headerText="Name" sortBy="#{med.name}" filterBy="#{med.name}" filterMatchMode="contains">
+            <p:column headerText="Name" sortBy="#{med.name}" globalFilter="true">
                <h:outputText value="#{med.name}"/>
             </p:column>
-            <p:column headerText="Description" filterBy="#{med.description}" filterMatchMode="contains">
+            <p:column headerText="Description" globalFilter="true">
                <h:outputText value="#{med.description}" title="#{med.description}"/>
             </p:column>
             <p:column headerText="Unit Price" sortBy="#{med.unitPrice}" style="text-align:right;">

--- a/src/main/webapp/WEB-INF/includes/admin/manage_service_catalog.xhtml
+++ b/src/main/webapp/WEB-INF/includes/admin/manage_service_catalog.xhtml
@@ -7,8 +7,84 @@
     <p:card header="Manage Service Catalog" styleClass="shadow-2 p-3">
         <h:form id="serviceCatalogForm" styleClass="p-fluid">
 
-            <p:messages id="catalogMessages" showDetail="true" closable="true" autoUpdate="true"/>
-            <p:growl id="growl" showDetail="true" life="4000"/>
+                    <p:messages id="catalogMessages" showDetail="true" closable="true" autoUpdate="true" />
+                    <p:growl id="growl" showDetail="true" life="4000" />
+
+                    <!-- =================== Add New Service =================== -->
+                    <p:fieldset legend="Add New Service Item" toggleable="true" collapsed="false" styleClass="mt-4">
+                        <div class="formgrid grid">
+
+                            <!-- Service Code -->
+                            <div class="field col-12 md:col-6 mb-3">
+                                <p:outputLabel for="serviceCode" value="Service Code" styleClass="mb-1 block" />
+                                <p:inputText id="serviceCode"
+                                             value="#{serviceCatalogAdminBean.newServiceCode}"
+                                             required="true"
+                                             requiredMessage="Service Code is required."
+                                             placeholder="e.g., CONSULT01, XRAY02" />
+                            </div>
+
+                            <!-- Service Name -->
+                            <div class="field col-12 md:col-6 mb-3">
+                                <p:outputLabel for="serviceName" value="Service Name" styleClass="mb-1 block" />
+                                <p:inputText id="serviceName"
+                                             value="#{serviceCatalogAdminBean.newServiceName}"
+                                             required="true"
+                                             requiredMessage="Service name is required." />
+                            </div>
+
+                            <!-- Default Cost -->
+                            <div class="field col-12 md:col-6 mb-3">
+                                <p:outputLabel for="serviceCost" value="Default Cost (UGX)" styleClass="mb-1 block" />
+                                <p:inputNumber id="serviceCost"
+                                               value="#{serviceCatalogAdminBean.newServiceDefaultCost}"
+                                               required="true"
+                                               requiredMessage="Default cost is required."
+                                               minValue="0.01"
+                                               decimalPlaces="2"
+                                               symbol=" UGX"
+                                               symbolPosition="p" />
+                            </div>
+
+                            <!-- Category -->
+                            <div class="field col-12 md:col-6 mb-3">
+                                <p:outputLabel for="serviceCategory" value="Category" styleClass="mb-1 block" />
+                                <p:selectOneMenu id="serviceCategory"
+                                                 value="#{serviceCatalogAdminBean.newServiceCategory}"
+                                                 required="true"
+                                                 requiredMessage="Category is required.">
+                                    <f:selectItem itemLabel="--- Select Category ---" itemValue="#{null}" noSelectionOption="true" />
+                                    <f:selectItems value="#{serviceCatalogAdminBean.availableServiceCategories}" var="cat"
+                                                   itemLabel="#{cat.displayName}" itemValue="#{cat}" />
+                                </p:selectOneMenu>
+                            </div>
+
+                            <!-- Description -->
+                            <div class="field col-12 mb-3">
+                                <p:outputLabel for="serviceDescription" value="Description (Optional)" styleClass="mb-1 block" />
+                                <p:inputTextarea id="serviceDescription"
+                                                 value="#{serviceCatalogAdminBean.newServiceDescription}"
+                                                 rows="3"
+                                                 autoResize="false" />
+                            </div>
+                        </div>
+
+                        <!-- Action Buttons -->
+                        <div class="flex justify-content-start mt-3">
+                            <p:commandButton value="Add Service"
+                                             action="#{serviceCatalogAdminBean.addNewServiceCatalogItem}"
+                                             update="@form"
+                                             process="@form"
+                                             icon="pi pi-plus"
+                                             styleClass="ui-button-success mr-2" />
+
+                            <p:commandButton value="Clear Form"
+                                             update="@form"
+                                             icon="pi pi-refresh"
+                                             process="@this"
+                                             styleClass="ui-button-warning" />
+                        </div>
+                    </p:fieldset>
 
             <!-- =================== Existing Service Items =================== -->
             <p:fieldset legend="Existing Service Items" toggleable="true" collapsed="true" styleClass="mt-3">
@@ -16,21 +92,38 @@
                 <p:dataTable id="catalogTable"
                              var="item"
                              value="#{serviceCatalogAdminBean.catalogItems}"
+                             globalFilterFunction="#{serviceCatalogAdminBean.globalFilterFunction}"
+                             filteredValue="#{serviceCatalogAdminBean.filteredCatalogItems}"
                              widgetVar="catalogTableWidget"
                              paginator="true" rows="10"
+                             paginatorPosition="bottom"
                              emptyMessage="No org.pahappa.systems.hms.navigation.services found in catalog."
                              scrollable="true" scrollHeight="300"
                              reflow="true">
+                    <!-- The header now contains the global filter input box -->
+                    <f:facet name="header">
+                        <div class="flex justify-content-between align-items-center">
 
-                    <p:column headerText="Code" sortBy="#{item.serviceCode}" filterBy="#{item.serviceCode}" filterMatchMode="contains">
+                            <!-- This is the global filter input -->
+                            <span class="p-input-icon-left">
+                           <p:inputText id="globalFilter"
+                                        placeholder="Search all fields..."
+                                        onkeyup="PrimeFaces.debounce(() => PF('catalogTableWidget').filter(), 300)"
+                                        style="width: 20rem;" />
+
+                        </span>
+                        </div>
+                    </f:facet>
+
+                    <p:column headerText="Code" sortBy="#{item.serviceCode}" globalFilter="true">
                         <h:outputText value="#{item.serviceCode}" />
                     </p:column>
 
-                    <p:column headerText="Name" sortBy="#{item.name}" filterBy="#{item.name}" filterMatchMode="contains">
+                    <p:column headerText="Name" sortBy="#{item.name}" globalFilter="true">
                         <h:outputText value="#{item.name}" />
                     </p:column>
 
-                    <p:column headerText="Category" sortBy="#{item.category}" filterBy="#{item.category}" filterMatchMode="exact">
+                    <p:column headerText="Category" sortBy="#{item.category}" globalFilter="true">
                         <f:facet name="filter">
                             <p:selectOneMenu onchange="PF('catalogTableWidget').filter()">
                                 <f:selectItem itemLabel="All" itemValue="#{null}" noSelectionOption="true" />
@@ -41,7 +134,7 @@
                         <h:outputText value="#{item.category.displayName}" />
                     </p:column>
 
-                    <p:column headerText="Default Cost" sortBy="#{item.defaultCost}" style="text-align:right;">
+                    <p:column headerText="Default Cost" sortBy="#{item.defaultCost}"  style="text-align:right;">
                         <h:outputText value="#{item.defaultCost}">
                             <f:convertNumber type="currency" currencySymbol="UGX " />
                         </h:outputText>
@@ -64,55 +157,7 @@
                 </p:dataTable>
             </p:fieldset>
 
-            <!-- =================== Add New Service =================== -->
-            <p:fieldset legend="Add New Service Item" toggleable="true" collapsed="false" styleClass="mt-4">
-                <p:panelGrid columns="2" layout="grid" styleClass="ui-panelgrid-blank ui-fluid"
-                             columnClasses="ui-g-12 ui-md-3, ui-g-12 ui-md-9">
 
-                    <p:outputLabel for="serviceCode" value="Service Code:" />
-                    <p:inputText id="serviceCode" value="#{serviceCatalogAdminBean.newServiceCode}"
-                                 required="true" requiredMessage="Service Code is required."
-                                 placeholder="e.g., CONSULT01, XRAY02" />
-
-                    <p:outputLabel for="serviceName" value="Service Name:" />
-                    <p:inputText id="serviceName" value="#{serviceCatalogAdminBean.newServiceName}"
-                                 required="true" requiredMessage="Service name is required." />
-
-                    <p:outputLabel for="serviceCost" value="Default Cost (UGX):" />
-                    <p:inputNumber id="serviceCost" value="#{serviceCatalogAdminBean.newServiceDefaultCost}"
-                                   required="true" requiredMessage="Default cost is required."
-                                   minValue="0.01" decimalPlaces="2" symbol=" UGX" symbolPosition="p" />
-
-                    <p:outputLabel for="serviceCategory" value="Category:" />
-                    <p:selectOneMenu id="serviceCategory" value="#{serviceCatalogAdminBean.newServiceCategory}"
-                                     required="true" requiredMessage="Category is required.">
-                        <f:selectItem itemLabel="--- Select Category ---" itemValue="#{null}" noSelectionOption="true"/>
-                        <f:selectItems value="#{serviceCatalogAdminBean.availableServiceCategories}" var="cat"
-                                       itemLabel="#{cat.displayName}" itemValue="#{cat}" />
-                    </p:selectOneMenu>
-
-                    <p:outputLabel for="serviceDescription" value="Description (Optional):" />
-                    <p:inputTextarea id="serviceDescription"
-                                     value="#{serviceCatalogAdminBean.newServiceDescription}"
-                                     rows="3" autoResize="false" />
-                </p:panelGrid>
-
-                <!-- Action Buttons -->
-                <div class="flex justify-content-start mt-3">
-                    <p:commandButton value="Add Service"
-                                     action="#{serviceCatalogAdminBean.addNewServiceCatalogItem}"
-                                     update="@form"
-                                     process="@form"
-                                     icon="pi pi-plus"
-                                     styleClass="ui-button-success mr-2" />
-
-                    <p:commandButton value="Clear Form"
-                                     update="@form"
-                                     icon="pi pi-refresh"
-                                     process="@this"
-                                     styleClass="ui-button-warning" />
-                </div>
-            </p:fieldset>
 
         </h:form>
     </p:card>


### PR DESCRIPTION
### What does this PR do?
This pull request enhances the administrative interface by adding a powerful global search filter to both the "Manage Service Catalog" and the "Manage Medication Catalog" pages. This feature provides administrators with a fast and efficient way to locate specific items by searching across multiple fields with a single input.
### Description of Task to be completed?

- Backing Bean Enhancements:

The ServiceCatalogAdminBean and a corresponding MedicationCatalogAdminBean have been updated to include a filteredItems list (e.g., private List<ServiceCatalogItem> filteredServices;).
This list, along with its getter and setter, is bound to the filteredValue attribute of the p:dataTable and is essential for PrimeFaces' filtering mechanism.

- Global Filter UI Implementation:

On both the service and medication catalog management pages, an <p:inputText id="globalFilter"> has been added to the <f:facet name="header"> of their respective p:dataTable components.
The input's onkeyup event is configured to call PF('widgetVar').filter(), where widgetVar is the unique identifier for each dataTable. This provides a real-time "search-as-you-type" experience.
The standard PrimeFaces client-side filtering pattern has been applied, removing any outdated or conflicting filter attributes from the p:dataTable tag.

- Column Configuration:

The globalFilter="true" attribute has been added to each <p:column> that should be included in the search. This includes fields like Item Code, Name, Category, and Description.
Columns that should not be searched, such as the "Actions" column, have been correctly configured without this attribute.
### How should this be manually tested?

- Test Case 1: Service Catalog Filter

Log in as an Administrator.
Navigate to the "Manage Service Catalog" page.
The full list of services should be visible.
In the "Search Keyword" input box at the top of the table, type a term matching part of a service's name (e.g., "Consult").

- Expected Result: The table should instantly filter to show only services containing "Consult" in their name or other searchable fields.

Clear the search box and type a category name (e.g., "Radiology").

- Expected Result: The table should filter to show all services in the Radiology category.

Clear the input to see the full list return.

- Test Case 2: Medication Catalog Filter

Navigate to the "Manage Medication Catalog" page.
Use the search box to filter by medication name or code.
Expected Result: The medication list should filter correctly and instantly, matching the behavior of the service catalog filter.
### Any background context you want to provide?
This feature continues the effort to standardize and improve the user experience across all administrative data management pages. By implementing the same robust global filtering pattern used for the Staff and Patient lists, we provide a consistent and powerful tool for administrators, which is especially important as the number of services and medications in the system grows.