### PR TITLE
Added global filter on patient payment history and prescriptions history

### DIFF
--- a/src/main/java/views/patient/PatientPrescriptionsList.java
+++ b/src/main/java/views/patient/PatientPrescriptionsList.java
@@ -5,14 +5,18 @@ import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.pahappa.systems.hms.models.Patient;
+import org.pahappa.systems.hms.models.Payment;
 import org.pahappa.systems.hms.models.Prescription;
 import org.pahappa.systems.hms.services.impl.PrescriptionServiceImpl;
 import views.UserAccountBean;
 
 
 import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @Named
 @ViewScoped
@@ -25,6 +29,7 @@ public class PatientPrescriptionsList implements Serializable {
     private final PrescriptionServiceImpl prescriptionService;
 
     private List<Prescription> patientPrescriptions =  new ArrayList<>();
+    private List<Prescription> filteredPrescriptions = new ArrayList<>();
     private Prescription selectedPrescription;
 
 
@@ -49,9 +54,38 @@ public class PatientPrescriptionsList implements Serializable {
         if (this.patientPrescriptions == null) {
             this.patientPrescriptions = new ArrayList<>();
         }
+        this.filteredPrescriptions = new ArrayList<>(patientPrescriptions);
+    }
+
+    public boolean globalFilterFunction(Object value, Object filter, Locale locale) {
+        if (value == null || filter == null) return true;
+
+        Prescription prescription = (Prescription) value;
+
+        // Case 1: Text filter from search box (String)
+        if (filter instanceof String filterText) {
+            String lowerFilter = filterText.toLowerCase().trim();
+            if (lowerFilter.isBlank()) return true;
+
+            return (prescription.getPaymentStatus() != null && prescription.getPaymentStatus().toString().toLowerCase().contains(lowerFilter)) ||
+                    (prescription.getPrescriptionDate() != null && prescription.getPrescriptionDate().toString().contains(lowerFilter)) ||
+                    (prescription.getTotalCost() > 0 && String.valueOf(prescription.getTotalCost()).toLowerCase().contains(lowerFilter));
+        }
+
+
+        return true; // fallback
     }
 
     // Getters and Setters
+
+    public List<Prescription> getFilteredPrescriptions() {
+        return filteredPrescriptions;
+    }
+
+    public void setFilteredPrescriptions(List<Prescription> filteredPrescriptions) {
+        this.filteredPrescriptions = filteredPrescriptions;
+    }
+
     public List<Prescription> getPatientPrescriptions() {
         return patientPrescriptions;
     }

--- a/src/main/webapp/WEB-INF/includes/patient/my_payment_history_content.xhtml
+++ b/src/main/webapp/WEB-INF/includes/patient/my_payment_history_content.xhtml
@@ -7,30 +7,37 @@
    <p:card header="My Payment History" styleClass="shadow-2 p-3">
       <h:form id="paymentHistoryForm">
 
-         <!-- Toolbar -->
-         <p:toolbar style="margin-bottom: 1rem;">
-            <p:toolbarGroup>
-               <p:commandButton value="Refresh" icon="pi pi-refresh"
-                                action="#{patientFinancialsBean.loadPaymentHistory}"
-                                update="paymentHistoryTable"
-                                process="@this"
-                                styleClass="ui-button-secondary"/>
-            </p:toolbarGroup>
-         </p:toolbar>
-
          <!-- Data Table -->
          <div style="overflow-x: auto;">
             <p:dataTable id="paymentHistoryTable"
+                         widgetVar="paymentHistoryTableWidget"
                          var="payment"
                          value="#{patientFinancialsBean.paymentHistory}"
+                         globalFilterFunction="#{patientFinancialsBean.globalFilterFunction}"
+                         filteredValue="#{patientFinancialsBean.filteredPayments}"
                          emptyMessage="You have no payment records."
                          styleClass="p-datatable-sm p-datatable-striped"
                          autoLayout="true"
                          reflow="true">
 
-               <!-- Header Title -->
+               <!-- The header now contains the global filter input box -->
                <f:facet name="header">
-                  <h:outputText value="All Payments Made by #{patientFinancialsBean.currentPatient.name}"/>
+                  <div class="flex justify-content-between align-items-center">
+                     <p:commandButton value="Refresh" icon="pi pi-refresh"
+                                      action="#{patientFinancialsBean.loadPaymentHistory}"
+                                      update="paymentHistoryTable"
+                                      process="@this"
+                                      styleClass="ui-button-secondary"/>
+
+                     <!-- This is the global filter input -->
+                     <span class="p-input-icon-left">
+                           <p:inputText id="globalFilter"
+                                        placeholder="Search all fields..."
+                                        onkeyup="PrimeFaces.debounce(() => PF('paymentHistoryTableWidget').filter(), 300)"
+                                        style="width: 20rem;" />
+
+                        </span>
+                  </div>
                </f:facet>
 
                <!-- Payment ID -->
@@ -40,8 +47,7 @@
 
                <!-- Payment Date (with date-only filter) -->
                <p:column headerText="Payment Date"
-                         filterBy="#{payment.paymentDate}"
-                         filterFunction="#{patientFinancialsBean.filterByDate}"
+                        globalFiter="true"
                          sortBy="#{payment.paymentDate}">
                   <f:facet name="filter">
                      <p:datePicker value="#{patientFinancialsBean.paymentDateFilter}"
@@ -55,20 +61,20 @@
                </p:column>
 
                <!-- Amount Paid -->
-               <p:column headerText="Amount Paid" sortBy="#{payment.amountPaid}" style="text-align: right;">
+               <p:column headerText="Amount Paid" sortBy="#{payment.amountPaid}" globalFiter="true" style="text-align: right;">
                   <h:outputText value="#{payment.amountPaid}">
                      <f:convertNumber type="currency" currencySymbol="UGX "/>
                   </h:outputText>
                </p:column>
 
                <!-- Payment For -->
-               <p:column headerText="Payment For">
+               <p:column headerText="Payment For" sortBy="#{payment.billId.billId} or #{payment.prescription.prescriptionId}">
                   <h:outputText value="Bill ##{payment.billId.billId}" rendered="#{payment.billId != null}"/>
                   <h:outputText value="Prescription ##{payment.prescription.prescriptionId}" rendered="#{payment.prescription != null}"/>
                </p:column>
 
                <!-- Payment Method -->
-               <p:column headerText="Method">
+               <p:column headerText="Method" sortBy="#{payment.method}" globalFiterr="true">
                   <h:outputText value="#{payment.method}"/>
                </p:column>
                <p:column headerText="Receipt" style="text-align: center; width: 5rem;">

--- a/src/main/webapp/WEB-INF/includes/patient/my_prescriptions.xhtml
+++ b/src/main/webapp/WEB-INF/includes/patient/my_prescriptions.xhtml
@@ -12,37 +12,49 @@
             <p:tab title="Prescription History">
                 <p:card>
                     <p:dataTable id="prescriptionsTable"
+                                 widgetVar="prescriptionsTableWidget"
                                  var="pres"
                                  value="#{patientPrescriptionsList.patientPrescriptions}"
+                                 globalFilterFunction="#{patientPrescriptionsList.globalFilterFunction}"
+                                 filteredValue="#{patientPrescriptionsList.filteredPrescriptions}"
                                  emptyMessage="You have no prescriptions on record."
                                  rows="10" paginator="true" paginatorPosition="bottom"
                                  rowsPerPageTemplate="5,10,20"
                                  reflow="true">
 
+                        <!-- The header now contains the global filter input box -->
                         <f:facet name="header">
                             <div class="flex justify-content-between align-items-center">
-                                <span class="text-xl font-bold">My Prescription History</span>
-                                <p:commandButton icon="pi pi-refresh" title="Refresh"
-                                                 action="#{patientPrescriptionsList.loadPrescriptions}"
+                                <p:commandButton value="Refresh" icon="pi pi-refresh"
+                                                 action="#{patientPrescriptionsList.loadPrescriptions()}"
                                                  update="prescriptionsTable"
                                                  process="@this"
-                                                 styleClass="ui-button-flat ui-button-secondary rounded-button"/>
+                                                 styleClass="ui-button-secondary"/>
+
+                                <!-- This is the global filter input -->
+                                <span class="p-input-icon-left">
+                           <p:inputText id="globalFilter"
+                                        placeholder="Search all fields..."
+                                        onkeyup="PrimeFaces.debounce(() => PF('prescriptionsTableWidget').filter(), 300)"
+                                        style="width: 20rem;" />
+
+                        </span>
                             </div>
                         </f:facet>
 
-                        <p:column headerText="Prescription Date" sortBy="#{pres.prescriptionDate}" style="width: 12rem;">
+                        <p:column headerText="Prescription Date" globalFilter="true" sortBy="#{pres.prescriptionDate}" style="width: 12rem;">
                             <h:outputText value="#{pres.prescriptionDate}">
                                 <f:convertDateTime type="localDate" dateStyle="long"/>
                             </h:outputText>
                         </p:column>
 
-                        <p:column headerText="Medications">
+                        <p:column headerText="Medications" globalFilter="true">
                             <h:outputText value="#{pres.prescribedMedications[0].medicationName}"
                                           rendered="#{not empty pres.prescribedMedications}"/>
                             <h:outputText value="..." rendered="#{pres.prescribedMedications.size() > 1}"/>
                         </p:column>
 
-                        <p:column headerText="Prescribed By" sortBy="#{pres.doctor.name}">
+                        <p:column headerText="Prescribed By" sortBy="#{pres.doctor.name}" globalFilter="true">
                             <h:outputText value="Dr. #{pres.doctor.name}" />
                         </p:column>
 


### PR DESCRIPTION
### What does this PR do?
This pull request enhances the patient-facing area of the application by implementing a global search filter on both the "My Payments" and "My Prescriptions" history pages. This allows patients to easily find specific records by typing a keyword, which filters the data tables in real-time across multiple fields.
### Description of Task to be completed?

1. Backing Bean Enhancements:

The PatientPaymentsBean has been updated with a private List<Payment> filteredPayments property (with getter/setter) to hold the state of the filtered payment list.
The PatientPrescriptionsBean has been updated with a private List<Prescription> filteredPrescriptions property (with getter/setter) to manage the filtered prescription list.

2.  Global Filter UI for Payment History:

In the my_payments_content.xhtml fragment, an <p:inputText id="globalFilter"> has been added to the header of the p:dataTable.
The input's onkeyup event is configured to call PF('paymentsTableWidget').filter() to trigger client-side filtering.
The globalFilter="true" attribute has been applied to searchable columns like "Bill/Prescription ID", "Payment Method", and "Transaction Reference".

3. Global Filter UI for Prescription History:

Similarly, in the my_prescriptions_content.xhtml fragment, a global filter input has been added to the header of the prescriptionsTable.
The onkeyup event triggers PF('prescriptionsTableWidget').filter().
Searchable columns like "Medication Name", "Dosage", "Frequency", and "Prescribed by" have been marked with globalFilter="true".
### How should this be manually tested?
1. Test Case 1: Filter Payment History
Log in as a Patient.
Navigate to the "My Payments" page (or the page containing the payment history).
A list of past payments should be visible.
In the "Search Keyword" input box above the table, type a part of a transaction reference number or a payment method (e.g., "CASH").
Expected Result: The table should instantly filter to show only payments that match the search term.
Clear the search box to see the full list return.

2.  Test Case 2: Filter Prescription History

Navigate to the "My Prescriptions" page.
A list of prescriptions should be visible.
In the "Search Keyword" input box, type the name of a medication (e.g., "Amoxicillin").
Expected Result: The table should filter to show only prescriptions that include that medication.
Clear the search and type the name of a doctor.
Expected Result: The table should filter to show only prescriptions from that doctor.
Clear the input to see the full list return.
### Any background context you want to provide?
This feature applies the same successful global filtering pattern used in the administrative "Manage Staff/Patients" sections to the patient-facing history views. This provides a consistent and powerful user experience across the application, making it easier for patients to find the information they need regarding their past interactions with the hospital.