### PR TITLE
Added global filter on patient appointment table

### DIFF
--- a/src/main/java/views/patient/AppointmentListBean.java
+++ b/src/main/java/views/patient/AppointmentListBean.java
@@ -1,5 +1,6 @@
 package views.patient;
 
+import org.pahappa.systems.hms.models.Patient;
 import views.UserAccountBean;
 import jakarta.annotation.PostConstruct;
 import jakarta.faces.view.ViewScoped;
@@ -23,6 +24,7 @@ public class AppointmentListBean implements Serializable {
     private UserAccountBean userAccountBean; // To get current doctor's ID
 
     private List<Appointment> appointmentsList;
+    private List<Appointment> filteredAppointmentsList;
 
     public AppointmentListBean() {
         this.appointmentService = new AppointmentServiceImpl();
@@ -41,9 +43,34 @@ public class AppointmentListBean implements Serializable {
         } else {
             System.out.println("StaffListBean: Loaded " + appointmentsList.size() + " staff members.");
         }
+        this.filteredAppointmentsList = new ArrayList<>(appointmentsList);
+    }
+
+    // ✅ Global Filter Function
+    public boolean globalFilterFunction(Object value, Object filter, java.util.Locale locale) {
+        if (value == null || filter == null) return true;
+
+        Appointment appointment = (Appointment) value;
+        if (filter instanceof String filterText) {
+            String lowerFilter = filterText.toLowerCase().trim();
+            if (lowerFilter.isBlank()) return true;
+            return (appointment.getDoctor().getName() != null && appointment.getDoctor().getName().toLowerCase().contains(filterText)) ||
+                    (appointment.getStatus().toString() != null && appointment.getStatus().toString().toLowerCase().contains(filterText)) ||
+                    (appointment.getDateTime() != null && appointment.getDateTime().toLocalDate().toString().contains(lowerFilter));
+        }
+        return  true;
     }
 
     // Getter for the JSF page
+
+    public List<Appointment> getFilteredAppointmentsList() {
+        return filteredAppointmentsList;
+    }
+
+    public void setFilteredAppointmentsList(List<Appointment> filteredAppointmentsList) {
+        this.filteredAppointmentsList = filteredAppointmentsList;
+    }
+
     public List<Appointment> getAppointmentsList() {
         return appointmentsList;
     }

--- a/src/main/webapp/WEB-INF/includes/patient/patient_appointment_list.xhtml
+++ b/src/main/webapp/WEB-INF/includes/patient/patient_appointment_list.xhtml
@@ -9,39 +9,51 @@
 
          <p:messages id="appointmentMessages" showDetail="true" closable="true" />
 
-         <!-- Toolbar -->
-         <p:toolbar styleClass="mb-3">
-            <p:toolbarGroup>
-               <p:commandButton value="Refresh List" icon="pi pi-refresh"
-                                action="#{patientListBean.refreshList}" update="appointmentTable"
-                                styleClass="ui-button-secondary ml-2" />
-            </p:toolbarGroup>
-         </p:toolbar>
 
          <!-- Scrollable Data Table -->
          <div style="overflow-x:auto; max-height: 500px;">
             <p:dataTable id="appointmentTable"
+                         widgetVar="appointmentTableWidget"
                          var="aptmnt"
                          value="#{appointmentListBean.appointmentsList}"
+                         globalFilterFunction="#{appointmentListBean.globalFilterFunction}"
+                         filteredValue="#{appointmentListBean.filteredAppointmentsList}"
                          emptyMessage="No appointments found."
                          styleClass="p-datatable-striped p-datatable-sm"
                          reflow="true"
                          scrollable="true"
                          scrollHeight="400">
+               <!-- The header now contains the global filter input box -->
+               <f:facet name="header">
+                  <div class="flex justify-content-between align-items-center">
+                     <p:commandButton value="Refresh" icon="pi pi-refresh"
+                                      action="#{patientListBean.refreshList}" update="appointmentTable"
+                                      styleClass="ui-button-secondary ml-2" />
+
+                     <!-- This is the global filter input -->
+                     <span class="p-input-icon-left">
+                           <p:inputText id="globalFilter"
+                                        placeholder="Search all fields..."
+                                        onkeyup="PrimeFaces.debounce(() => PF('appointmentTableWidget').filter(), 300)"
+                                        style="width: 20rem;" />
+
+                        </span>
+                  </div>
+               </f:facet>
 
                <p:column headerText="ID" style="width:5%;">
                   <h:outputText value="#{aptmnt.appointmentId}" />
                </p:column>
 
-               <p:column headerText="Doctor Name">
+               <p:column headerText="Doctor Name" sortBy="#{aptmnt.doctor.name}" globaFilter="true">
                   <h:outputText value="#{aptmnt.doctor.name}" />
                </p:column>
 
-               <p:column headerText="Date Time">
+               <p:column headerText="Date Time" sortBy="#{aptmnt.dateTime}" globalFilter="true">
                   <h:outputText value="#{aptmnt.dateTime}" />
                </p:column>
 
-               <p:column headerText="Status">
+               <p:column headerText="Status" sortBy="#{aptmnt.status}" globalFilter="true">
                   <h:outputText value="#{aptmnt.status}" />
                </p:column>
 


### PR DESCRIPTION
### What does this PR do?
This pull request enhances the various appointment list views (for patients, doctors, and receptionists) by implementing a unified global search filter. This allows users to quickly find specific appointments by searching across multiple relevant fields like patient name, doctor name, status, or reason.
### Description of Task to be completed?

- Backing Bean Enhancement:

The relevant backing beans that manage appointment lists (e.g.,  AppointmentsBean) have been updated.
A private List<Appointment> filteredAppointments; property, along with its getter and setter, has been added to each bean to store the state of the filtered data, binding to the p:dataTable's filteredValue attribute.

- Global Filter UI Implementation:

Across all appointment list fragments (e.g., doctor_appointment_list.xhtml, patient_appointment_list.xhtml), a global search <p:inputText> has been added to the <f:facet name="header"> of the p:dataTable.
The onkeyup event on this input is configured to call PF('appointmentsTableWidget').filter() to provide a real-time "search-as-you-type" experience.
The globalFilter="true" attribute has been applied to all searchable columns, including Patient Name, Doctor Name, Appointment Status, and Reason.
### How should this be manually tested?
Log in as any user who can view a list of appointments (Patient, Doctor, Receptionist, or Administrator).
Navigate to the relevant appointments page (e.g., "My Appointments" for a patient, "Patient Appointments" for a doctor).
A dataTable listing appointments should be visible.
In the "Search Keyword" input box above the table, perform the following searches:
Type part of a patient's name.
Type part of a doctor's name.
Type an appointment status (e.g., "COMPLETED").
Expected Result: For each search, the table should instantly filter to show only the appointment records that match the entered term in any of the searchable fields.
Clear the search box.
Expected Result: The full, unfiltered list of appointments should reappear.
### Any background context you want to provide?
This feature applies our standard global filtering pattern to appointment management views. This creates a consistent and efficient user experience across all major data tables in the application, allowing users to easily locate information without manually scanning through pages of data.