### PR TITLE
Refactor Doctor UI for Improved Workflow

### DIFF
--- a/src/main/java/org/pahappa/systems/hms/navigation/PageNavigationBean.java
+++ b/src/main/java/org/pahappa/systems/hms/navigation/PageNavigationBean.java
@@ -24,7 +24,7 @@ public class PageNavigationBean implements Serializable {
             if (userAccountBean.isAdministrator()) {
                 navigateToDashboard();
             } else if (userAccountBean.isDoctor()) {
-                navigateToDoctorAppointments();
+                navigateToDoctorDashboard();
             } else if (userAccountBean.isPatient()) {
                 navigateToPatientAppointments();
             } else if (userAccountBean.isReceptionist()) {
@@ -45,12 +45,12 @@ public class PageNavigationBean implements Serializable {
         this.currentPage = "/WEB-INF/includes/admin/dashboard_content.xhtml";
         return null;
     }
-
-    public String navigateAddNewStaff() {
-        this.selectedMenu =  "staffRegistration";
-        this.currentPage = "/WEB-INF/includes/admin/staff_registration.xhtml";
+    public String navigateToDoctorDashboard() {
+        this.selectedMenu = "dashboard";
+        this.currentPage = "/WEB-INF/includes/doctor/dashboard.xhtml";
         return null;
     }
+
 
     public String navigateToUnpaidPrescriptions() {
         this.selectedMenu =  "unpaidPrescriptions";
@@ -58,11 +58,6 @@ public class PageNavigationBean implements Serializable {
         return null;
     }
 
-    public String navigateAddNewPatient() {
-        this.selectedMenu = "patientRegistration";
-        this.currentPage = "/WEB-INF/includes/receptionist/patient_registration.xhtml";
-        return null;
-    }
 
     public String navigateToViewStaff() {
         this.selectedMenu = "staff_list";

--- a/src/main/webapp/WEB-INF/includes/doctor/manage_schedule.xhtml
+++ b/src/main/webapp/WEB-INF/includes/doctor/manage_schedule.xhtml
@@ -27,9 +27,27 @@
             </div>
          </p:fieldset>
 
-         <!-- ========== Add New Slots ========== -->
-         <p:outputPanel id="newSlotsPanel" styleClass="mt-4">
-            <p:fieldset legend="Add New Available Time Slots for #{doctorScheduleBean.selectedDateForView}" toggleable="true">
+         <!-- ========== Button to Open Dialog ========== -->
+         <div class="mt-3">
+            <p:commandButton value="Add Time Slots"
+                             icon="pi pi-plus"
+                             onclick="PF('addSlotDialog').show()"
+                             type="button"
+                             styleClass="ui-button-success" />
+         </div>
+
+         <!-- ========== Dialog for Adding New Slots ========== -->
+         <p:dialog header="Add New Available Time Slots for #{doctorScheduleBean.selectedDateForView}"
+                   widgetVar="addSlotDialog"
+                   modal="true"
+                   closable="true"
+                   resizable="false"
+                   draggable="false"
+                   showEffect="fade"
+                   hideEffect="fade"
+                   width="40vw">
+
+            <h:panelGrid columns="1" cellpadding="5" styleClass="p-fluid">
                <p:selectManyCheckbox id="timeSlots"
                                      value="#{doctorScheduleBean.timesToAdd}"
                                      layout="responsive"
@@ -42,12 +60,13 @@
 
                <p:commandButton value="Add Selected Slots"
                                 action="#{doctorScheduleBean.addSelectedSlots()}"
-                                icon="pi pi-plus"
+                                icon="pi pi-check"
                                 process="@form"
                                 update="@form:scheduleMessages existingSlotsPanel"
+                                oncomplete="PF('addSlotDialog').hide()"
                                 styleClass="mt-3" />
-            </p:fieldset>
-         </p:outputPanel>
+            </h:panelGrid>
+         </p:dialog>
 
          <!-- ========== Existing Slots ========== -->
          <p:outputPanel id="existingSlotsPanel" styleClass="mt-4">

--- a/src/main/webapp/template.xhtml
+++ b/src/main/webapp/template.xhtml
@@ -92,6 +92,14 @@
                                    rendered="#{userAccountBean.isAdministrator() or userAccountBean.isAccountant()}"
                                    update=":pageContentForm:mainContentPanel :menuForm"
                                    styleClass="menu-link #{pageNavigationBean.selectedMenu == 'dashboard' ? 'menu-link-active' : ''}" />
+                    <!-- Dashboard (Admin only) -->
+                    <p:commandLink value="Dashboard"
+                                   icon="pi pi-home"
+                                   action="#{pageNavigationBean.navigateToDoctorDashboard()}"
+                                   rendered="#{userAccountBean.isDoctor() }"
+                                   update=":pageContentForm:mainContentPanel :menuForm"
+                                   styleClass="menu-link #{pageNavigationBean.selectedMenu == 'dashboard' ? 'menu-link-active' : ''}" />
+
 
                     <!-- Patient Links -->
                     <p:commandLink value="Book Appointment"


### PR DESCRIPTION
### What does this PR do?
This pull request refactors and enhances the user interface for the Doctor role to create a more efficient and modern workflow. It updates the main navigation, converts the "Add Availability" feature into a modal dialog, and sets the new Doctor Dashboard as the default landing page.
### Description of Task to be completed?
Template and Navigation Updates (template.xhtml, PageNavigationBean.java):
A "Dashboard" p:menuitem has been added to the Doctor's menu in the main template, providing a clear link back to their home screen.
The PageNavigationBean's init() method has been updated to make the Doctor Dashboard the default page that loads immediately after a doctor logs in.
"Add Availability" Refactored to a Dialog (manage_schedule_content.xhtml):
The functionality for adding new time slots on the "Manage My Schedule" page has been moved from an inline form into a p:dialog.
A new "Add Availability" button is now present on the page, which opens this modal dialog. This declutters the main view, which now focuses primarily on displaying the existing schedule.
Backing Bean Logic (DoctorScheduleBean.java):
The DoctorScheduleBean has been updated to manage the state of the new "Add Availability" dialog.
An actionListener on the trigger button prepares the dialog for a specific date.
The "Add Selected Slots" button inside the dialog now uses AJAX to submit the new slots. Upon success, the dialog closes, and the main availability list on the underlying page is automatically refreshed to show the new entries.
### How should this be manually tested?

- Test Case 1: Doctor Login and Navigation

Log in as a user with the DOCTOR role.
Expected Result: You should land directly on the Doctor Dashboard page, not the schedule management page.
In the sidebar menu, click the "Manage My Schedule" link. You should be taken to the schedule view.
Click the new "Dashboard" link in the sidebar menu.
Expected Result: You should be correctly navigated back to the Doctor Dashboard.

- Test Case 2: Add Availability via Dialog

From the Doctor Dashboard, navigate to the "Manage My Schedule" page.
Click the "Add Availability" button.
Expected Result: A modal dialog should appear, allowing you to select a date and choose time slots to add.
Select a date and one or more time slots, then click "Add Selected Slots".
Expected Result:
The dialog should close.
A success message should appear.
The main list of available slots on the page should refresh to include the newly added times.
### Any background context you want to provide?
This refactoring is part of a larger effort to modernize the application's user experience. By converting page sections into context-aware dialogs, we reduce full-page loads and create a smoother, single-page-application (SPA) feel. Setting a role-specific dashboard as the default landing page also immediately provides the most relevant information to the user upon login.